### PR TITLE
feat: use a non-root user for the manager

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,7 +1,7 @@
 name: Pull Request
 
 on:
-  pull-request:
+  pull_request:
     branches:
       - main
     paths:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Seldon Core Operator OCI Image
 
 This repository is intended as a demonstration of how to port an OCI image that it otherwise
-defined using a `Dockerfile` to one built with [rockcraft](https://github.com/canonical/rockcraft). 
+defined using a `Dockerfile` to one built with [rockcraft](https://github.com/canonical/rockcraft).
 
 It provides a direct port of this [Dockerfile](https://github.com/SeldonIO/seldon-core/blob/5591c42b6a40a44641b848d86f9228f623c64598/operator/Dockerfile).
 
@@ -33,6 +33,5 @@ $ docker run --rm -it jnsgruk/seldon-core-operator:1.14.1
 - [ ] Validate if the YAML resources in `/tmp/operator-resources` are required
 - [ ] Test with an actual charm deployment
 - [ ] Fine-tune the default Pebble layer
-- [ ] Run the operator as a non-root user
+- [x] Run the operator as a non-root user
 - [ ] Trim the default image size using [chiselled ubuntu](https://github.com/canonical/chisel)
-

--- a/files/001-default.yaml
+++ b/files/001-default.yaml
@@ -8,3 +8,4 @@ services:
     override: replace
     command: /opt/seldon-core-operator/manager --enable-leader-election --webhook-port 4443 --create-resources true
     startup: enabled
+    user: seldon

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -12,7 +12,7 @@ description: |
 
 version: "1.14.1"
 license: Apache-2.0
-base: ubuntu:22.04
+base: ubuntu:20.04
 platforms:
   amd64:
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -42,7 +42,7 @@ parts:
       # TODO: Validate if we indeed need to do this given that the charm overrides the /tmp dir
       # Generate the resources per the upstream OCI image
       make generate-resources
-      
+
       # Install the generated resources into /tmp/operator-resources
       res="$CRAFT_PART_INSTALL/tmp/operator-resources/"
       install -D generated/v1_service_seldon-webhook-service.yaml "${res}/service.yaml"
@@ -63,7 +63,7 @@ parts:
       set -x
       mkdir -p $CRAFT_PART_INSTALL/opt/seldon-core-operator/licenses/mpl_source
       cd $CRAFT_PART_INSTALL/opt/seldon-core-operator/licenses/mpl_source
-      
+
       # Per https://github.com/SeldonIO/seldon-core/blob/5591c42b6a40a44641b848d86f9228f623c64598/operator/Dockerfile
       wget -qO armon-consul-api.tar.gz https://github.com/armon/consul-api/archive/master.tar.gz
       wget -qO go-sql-driver-mysql.tar.gz https://github.com/go-sql-driver/mysql/archive/master.tar.gz
@@ -97,3 +97,14 @@ parts:
     stage:
       - var/lib/pebble/default/layers/001-default.yaml
 
+  non-root-user:
+    plugin: nil
+    after: [default-config]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1000 seldon
+      useradd -R $CRAFT_OVERLAY -M -r -u 1000 -g seldon seldon
+    override-prime: |
+      craftctl default
+      chown -R 1000:1000 opt/seldon-core-operator
+      chown -R 1000:1000 tmp/operator-resources


### PR DESCRIPTION
Adds a non-root user/group named `seldon` to start the manager with.